### PR TITLE
feat: Adds a configurable set of allowed contract creators

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -78,6 +78,7 @@ var (
 		utils.TxPoolAccountQueueFlag,
 		utils.TxPoolGlobalQueueFlag,
 		utils.TxPoolLifetimeFlag,
+		utils.TxPoolAllowedContractPublishersFlag,
 		utils.FastSyncFlag,
 		utils.LightModeFlag,
 		utils.SyncModeFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -123,6 +123,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.TxPoolAccountQueueFlag,
 			utils.TxPoolGlobalQueueFlag,
 			utils.TxPoolLifetimeFlag,
+			utils.TxPoolAllowedContractPublishersFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -289,6 +289,11 @@ var (
 		Usage: "Maximum amount of time non-executable transaction are queued",
 		Value: eth.DefaultConfig.TxPool.Lifetime,
 	}
+	TxPoolAllowedContractPublishersFlag = cli.StringFlag{
+		Name:  "txpool.allowedaccountpublishers",
+		Usage: "A list of account addresses that are allowed to publish contracts",
+		Value: "",
+	}
 	// Performance tuning settings
 	CacheFlag = cli.IntFlag{
 		Name:  "cache",
@@ -937,6 +942,14 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	}
 	if ctx.GlobalIsSet(TxPoolLifetimeFlag.Name) {
 		cfg.Lifetime = ctx.GlobalDuration(TxPoolLifetimeFlag.Name)
+	}
+	if ctx.GlobalIsSet(TxPoolAllowedContractPublishersFlag.Name) {
+		contracts := strings.Split(ctx.GlobalString(TxPoolAllowedContractPublishersFlag.Name), ",")
+		for _, contract := range contracts {
+			if common.IsHexAddress(contract) {
+				cfg.AllowedContractPublishers[common.HexToAddress(contract)] = true
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Let's configurably whitelist different accounts.

Possible to hardcode them in source code,
to add them into the configuration file:

```
[Eth.TxPool.AllowedContractPublishers]
0x2b0ac2e90341cfbe4154cad43a4bb70e520919ef = true
0xf1d5c35aeb855e6865e4062036e645f2815ba4cc = true
```

or set via ```--txpool.allowedaccountpublishers``` command line flags.

If someone unauthorized sends the contract creation transaction, we log this:

```INFO [06-28|21:15:34] Unauthorized contract creation attempt from  contract=0x7674DdAC6f8509DD3a54416339503CAa60a3d676
INFO [06-28|21:15:34] Unauthorized contract creation attempt from  contract=0x7674DdAC6f8509DD3a54416339503CAa60a3d676
INFO [06-28|21:15:34] Unauthorized contract creation attempt from  contract=0x7674DdAC6f8509DD3a54416339503CAa60a3d676


```
